### PR TITLE
Updated colliders in prefabs by running 'ed_physxUpdatePrefabsWithColliderComponents' command

### DIFF
--- a/Assets/RoboVac/RobotVacuum.prefab
+++ b/Assets/RoboVac/RobotVacuum.prefab
@@ -858,7 +858,7 @@
                     }
                 },
                 "Component_[12927181747641970582]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 12927181747641970582,
                     "ColliderConfiguration": {
                         "MaterialSlots": {
@@ -3724,7 +3724,7 @@
                     "Id": 11858580036815791673
                 },
                 "Component_[1817880946152815022]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 1817880946152815022,
                     "ColliderConfiguration": {
                         "MaterialSlots": {


### PR DESCRIPTION
Note
This is part of the work to separate PhysX Collider into 2 components: https://github.com/o3de/o3de/pull/14725.
This is currently as draft to avoid submitting it too early.

Reviewers
Please review and approve this draft and once the main change is submitted into o3de I will merge this as well.

Testing
All converted prefabs were processed successfully by the Asset Processor.
Started simulation and drove vacuum robot around with rqt_robot_steering, checked LiDAR data.