### PR TITLE
Fix fail find engine if last engine incompatible

### DIFF
--- a/cmake/EngineFinder.cmake
+++ b/cmake/EngineFinder.cmake
@@ -140,6 +140,10 @@ endforeach()
 
 if(O3DE_MOST_COMPATIBLE_ENGINE_PATH)
     message(STATUS "Selecting engine '${O3DE_MOST_COMPATIBLE_ENGINE_PATH}'")
+    # Make sure PACKAGE_VERSION_COMPATIBLE is set so Findo3de.cmake knows
+    # compatibility was checked
+    set(PACKAGE_VERSION_COMPATIBLE True)
+    set(PACKAGE_VERSION O3DE_MOST_COMPATIBLE_ENGINE_VERSION)
     list(APPEND CMAKE_MODULE_PATH "${O3DE_MOST_COMPATIBLE_ENGINE_PATH}/cmake")
     return()
 endif()


### PR DESCRIPTION
Fixes an issue where cmake may fail to find an engine if the last engine checked is incompatible.  Bringing this fix over from the main o3de repo:  https://github.com/o3de/o3de/pull/15131