### PR TITLE
Set default tag for O3DE to critical fix for broken PyYaml dependencies

### DIFF
--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -19,7 +19,7 @@ ARG IMAGE_TYPE=simulation  # Default to 'simulation'
 
 # Arguments for the source repos needed for the robot vacuum sample docker
 ARG O3DE_REPO=https://github.com/o3de/o3de.git
-ARG O3DE_BRANCH=3ec71ff
+ARG O3DE_BRANCH=5b30aaf
 
 ARG O3DE_EXTRAS_REPO=https://github.com/o3de/o3de-extras.git
 ARG O3DE_EXTRAS_BRANCH=3464657


### PR DESCRIPTION
An [upstream update](https://github.com/o3de/o3de/issues/16392) to PYYAML broke the python workflow which affects all O3DE projects. This fix updates the default tag for O3DE to the [commit](https://github.com/o3de/o3de/commit/5b30aafe61dff0763eb42a4f34aeb816bbfbb8a6) that fixes this.


