### PR TITLE
Change ROS2FrameComponent to ROS2FrameEditorComponent (next release)

### DIFF
--- a/Assets/RoboVac/RobotVacuum.prefab
+++ b/Assets/RoboVac/RobotVacuum.prefab
@@ -4588,10 +4588,9 @@
                     ]
                 },
                 "Component_[15910097906063283013]": {
-                    "$type": "GenericComponentWrapper",
+                    "$type": "ROS2FrameEditorComponent",
                     "Id": 15910097906063283013,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent",
+                    "ROS2FrameConfiguration": {
                         "Namespace Configuration": {
                             "Namespace Strategy": 1
                         },
@@ -4817,10 +4816,9 @@
                     "Id": 18249910351855492071
                 },
                 "Component_[3490167280358485747]": {
-                    "$type": "GenericComponentWrapper",
+                    "$type": "ROS2FrameEditorComponent",
                     "Id": 3490167280358485747,
-                    "m_template": {
-                        "$type": "ROS2FrameComponent",
+                    "ROS2FrameConfiguration": {
                         "Namespace Configuration": {
                             "Namespace Strategy": 1
                         },


### PR DESCRIPTION
**Breaking change**
This PR is in reference to https://github.com/o3de/o3de-extras/pull/593.

I've updated all prefabs to include the ROS2FrameEditorComponent instead of the ROS2FrameComponent.