### PR TITLE
update docker readme/file

### DIFF
--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -19,10 +19,10 @@ ARG IMAGE_TYPE=simulation  # Default to 'simulation'
 
 # Arguments for the source repos needed for the robot vacuum sample docker
 ARG O3DE_REPO=https://github.com/o3de/o3de.git
-ARG O3DE_BRANCH=5b30aaf
+ARG O3DE_BRANCH=2310.1
 
 ARG O3DE_EXTRAS_REPO=https://github.com/o3de/o3de-extras.git
-ARG O3DE_EXTRAS_BRANCH=3464657
+ARG O3DE_EXTRAS_BRANCH=2310.1
 
 ARG LOFT_GEM_REPO=https://github.com/o3de/loft-arch-vis-sample.git
 ARG LOFT_GEM_BRANCH=main
@@ -99,7 +99,7 @@ COPY cleanup.bash /data/workspace/cleanup.bash
 RUN if [ "${IMAGE_TYPE}" = "simulation" ]; then \
         apt-get install -y --no-install-recommends ros-${ROS_DISTRO}-desktop && \
         cd $WORKSPACE && \
-        git clone --recursive $O3DE_REPO && \
+        git clone $O3DE_REPO && \
         git -C $WORKSPACE/o3de checkout $O3DE_BRANCH &&\
         git -C $WORKSPACE/o3de lfs install && \
         git -C $WORKSPACE/o3de lfs pull && \
@@ -108,12 +108,12 @@ RUN if [ "${IMAGE_TYPE}" = "simulation" ]; then \
         git clone $O3DE_EXTRAS_REPO && \
         git -C $WORKSPACE/o3de-extras checkout $O3DE_EXTRAS_BRANCH &&\
         $WORKSPACE/o3de/scripts/o3de.sh register -gp $WORKSPACE/o3de-extras/Gems/ROS2 && \
-        git clone --recursive $LOFT_GEM_REPO && \
+        git clone $LOFT_GEM_REPO && \
         git -C $WORKSPACE/loft-arch-vis-sample checkout $LOFT_GEM_BRANCH &&\
         git -C $WORKSPACE/loft-arch-vis-sample lfs install && \
         git -C $WORKSPACE/loft-arch-vis-sample lfs pull && \
         $WORKSPACE/o3de/scripts/o3de.sh register -gp $WORKSPACE/loft-arch-vis-sample/Gems/ArchVis/ && \
-        git clone --recursive $ROBOT_VAC_SAMPLE_REPO && \
+        git clone $ROBOT_VAC_SAMPLE_REPO && \
         git -C $WORKSPACE/RobotVacuumSample checkout $ROBOT_VAC_SAMPLE_BRANCH &&\
         git -C $WORKSPACE/RobotVacuumSample lfs install && \
         git -C $WORKSPACE/RobotVacuumSample lfs pull && \

--- a/Docker/README.md
+++ b/Docker/README.md
@@ -89,13 +89,18 @@ Alternatively, you can use [Rocker](https://github.com/osrf/rocker) to run a GPU
 Launch the built simulation docker image with the following rocker command
 
 ```
-rocker --x11 --nvidia o3de_robot_vacuum_simulation:latest /data/workspace/LaunchSimulation.bash
+rocker --x11 --nvidia --network="bridge" o3de_robot_vacuum_simulation:latest /data/workspace/LaunchSimulation.bash
 ```
 
 Once the simulation is up and running, launch the robot application docker image, which will bring up RViz to control the robot.
 
 ```
-rocker --x11 --nvidia o3de_robot_vacuum_navstack:latest /data/workspace/LaunchNavStack.bash
+rocker --x11 --nvidia --network="bridge" o3de_robot_vacuum_navstack:latest /data/workspace/LaunchNavStack.bash
+```
+
+Note: you might reuse the simulation docker image instead.
+```
+rocker --x11 --nvidia --network="bridge" o3de_robot_vacuum_simulation:latest /data/workspace/LaunchNavStack.bash
 ```
 
 ## Advanced Options
@@ -125,8 +130,8 @@ In addition the repositories, the following arguments target the branch, commit,
 
 | Argument                | Repository                       | Default     |
 |-------------------------|----------------------------------|-------------|
-| O3DE_BRANCH             | O3DE                             | 3ec71ff     |
-| O3DE_EXTRAS_BRANCH      | O3DE Extras                      | 3464657     |
+| O3DE_BRANCH             | O3DE                             | 2310.1      |
+| O3DE_EXTRAS_BRANCH      | O3DE Extras                      | 2310.1      |
 | LOFT_GEM_BRANCH         | Loft ArchVis Sample Scene        | main        |
 | ROBOT_VAC_SAMPLE_BRANCH | Loft Scene Simulation repository | main        |
 

--- a/project.json
+++ b/project.json
@@ -21,5 +21,5 @@
         "ROS2",
         "ArchVis"
     ],
-    "engine_version": "2.1.0"
+    "engine_version": "2.2.0"
 }


### PR DESCRIPTION
Dockerfile was using specific tags in `development` branches - this should be fixed as well. In particular, it was using:
- o3de Jul 18, 2023
- o3de-extras Jun 13, 2023

Now, the `main` branch, release `2310.1` is used instead. 